### PR TITLE
Duplicate remove of old crontabs

### DIFF
--- a/install/update.php
+++ b/install/update.php
@@ -5669,12 +5669,6 @@ function pluginFusioninventoryUpdate($current_version, $migrationname='Migration
                                'comment'=>'Clean agents not contacted since xxx days'));
    }
 
-   // remove old crontasks
-   if ($crontask->getFromDBbyName('PluginFusioninventoryTaskjob', 'updatedynamictasks')) {
-      $DB->query("DELETE FROM glpi_crontasks WHERE itemtype = 'glpi_crontasks'
-                                             AND name = 'updatedynamictasks'");
-   }
-
    /*
     * Update task's agents list from dynamic group periodically in order to automatically target new
     * computer.


### PR DESCRIPTION
I think upstream does the same thing differently on:
https://github.com/TECLIB/fusioninventory-for-glpi/blob/teclib/remove_crontasks/install/update.php#L5662
